### PR TITLE
.github/workflows: Always enable int and size_t offsets

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -73,6 +73,8 @@ jobs:
           -DKokkosKernels_INST_FLOAT=ON \
           -DKokkosKernels_INST_LAYOUTLEFT:BOOL=ON \
           -DKokkosKernels_INST_LAYOUTRIGHT:BOOL=ON \
+          -DKokkosKernels_INST_OFFSET_INT=ON \
+          -DKokkosKernels_INST_OFFSET_SIZE_T=ON \
           -DKokkosKernels_ENABLE_TPL_CUSPARSE=OFF \
           -DKokkosKernels_ENABLE_TPL_CUBLAS=OFF \
           ..


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos-kernels/pull/1363.